### PR TITLE
Fix: Resolve TypeScript type error in Addition Adventure game

### DIFF
--- a/src/app/games/addition-adventure/page.tsx
+++ b/src/app/games/addition-adventure/page.tsx
@@ -220,7 +220,7 @@ const AdditionAdventurePage: NextPage = () => {
                 </div>
               )}
               {/* Ensure some space if no feedback is shown, to prevent layout jumps */}
-              {phase === 'summingTime' && !dragFeedback && !(phase === 'finalFeedback' || phase === 'awaitingConfirmation') && (
+              {phase === 'summingTime' && !dragFeedback && (
                 <div className="h-16 mb-4"></div>
               )}
 


### PR DESCRIPTION
I removed a redundant condition in `src/app/games/addition-adventure/page.tsx` that was causing a TypeScript type error during the build process. The condition `!(phase === 'finalFeedback' || phase === 'awaitingConfirmation')` was found to be unnecessary when `phase === 'summingTime'` was already true, as these game phases are mutually exclusive.

The build now completes successfully after this correction.